### PR TITLE
Fix #5: Use different names for draft implementations.

### DIFF
--- a/draft-thomson-http-mice.md
+++ b/draft-thomson-http-mice.md
@@ -174,6 +174,13 @@ As a special case, the encoding of an empty payload is itself an empty message
 (i.e. it omits the initial record size), and its integrity proof is
 SHA-256("\0").
 
+*RFC EDITOR: Please remove the next paragraph before publication.*
+
+Implementations of drafts of this specification MUST implement a content
+encoding named "mi-sha256-draft#" instead of the "mi-sha256" content encoding
+specified by the final RFC, with "#" replaced by the draft number being
+implemented. For example, implementations of draft-thomson-http-mice-03 would
+implement "mi-sha256-draft3".
 
 ## Content Encoding Structure {#records}
 
@@ -273,6 +280,13 @@ which they were applied.
 The MI header MAY be omitted if the sender intends for the receiver to acquire
 the integrity proof for the first record by other means.
 
+*RFC EDITOR: Please remove the next paragraph before publication.*
+
+Implementations of drafts of this specification MUST implement an HTTP header
+field named "MI-Draft#" instead of the "MI" header field specified by the final
+RFC, with "#" replaced by the draft number being implemented. For example,
+implementations of draft-thomson-http-mice-03 would implement "MI-Draft3".
+
 
 ## MI Header Field Parameters
 
@@ -285,6 +299,11 @@ mi-sha256:
   message.  This provides integrity for the entire message body.  This value is
   encoded using base64url encoding [RFC7515].
 
+*RFC EDITOR: Please remove the next paragraph before publication.*
+
+Implementations of drafts of this specification MUST use a parameter named the
+same as the "mi-sha256-draft#" content encoding they implement, with the meaning
+described for "mi-sha256" above.
 
 # Examples
 

--- a/draft-thomson-http-mice.md
+++ b/draft-thomson-http-mice.md
@@ -177,10 +177,10 @@ SHA-256("\0").
 *RFC EDITOR: Please remove the next paragraph before publication.*
 
 Implementations of drafts of this specification MUST implement a content
-encoding named "mi-sha256-draft#" instead of the "mi-sha256" content encoding
-specified by the final RFC, with "#" replaced by the draft number being
+encoding named "mi-sha256-##" instead of the "mi-sha256" content encoding
+specified by the final RFC, with "##" replaced by the draft number being
 implemented. For example, implementations of draft-thomson-http-mice-03 would
-implement "mi-sha256-draft3".
+implement "mi-sha256-03".
 
 ## Content Encoding Structure {#records}
 
@@ -282,10 +282,8 @@ the integrity proof for the first record by other means.
 
 *RFC EDITOR: Please remove the next paragraph before publication.*
 
-Implementations of drafts of this specification MUST implement an HTTP header
-field named "MI-Draft#" instead of the "MI" header field specified by the final
-RFC, with "#" replaced by the draft number being implemented. For example,
-implementations of draft-thomson-http-mice-03 would implement "MI-Draft3".
+Implementations of drafts of this specification use the "MI" header field
+instead of renaming it to MI-## like the "mi-sha256" content encoding.
 
 
 ## MI Header Field Parameters
@@ -302,7 +300,7 @@ mi-sha256:
 *RFC EDITOR: Please remove the next paragraph before publication.*
 
 Implementations of drafts of this specification MUST use a parameter named the
-same as the "mi-sha256-draft#" content encoding they implement, with the meaning
+same as the "mi-sha256-##" content encoding they implement, with the meaning
 described for "mi-sha256" above.
 
 # Examples


### PR DESCRIPTION
I'm not tied at all to the particular names here, or where they're expressed within the draft.